### PR TITLE
chore: git-ignoring node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node/node_modules


### PR DESCRIPTION
Adding the node_modules directory to the ignore list so we don't push those changes into our codebase.
Ideally we'll use a lock-file to reproduce our dependencies in our CI/CD, and keep our repository light-weight.